### PR TITLE
Current dependencies and fix of cssprocessor option parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Fork of SebastianM/grunt-fscss to update dependencies. switched peerDep of grunt to grunt >=0.4.5
+
 # grunt-fscss [![Build Status](https://secure.travis-ci.org/SebastianM/grunt-fscss.png?branch=master)](http://travis-ci.org/SebastianM/grunt-fscss)
 
 > Replaces media references in CSS files with valid FirstSpirit $CMS_REF(media:"")$ function calls.

--- a/lib/cssprocessor.js
+++ b/lib/cssprocessor.js
@@ -12,6 +12,7 @@ var HTTP_URL_REGEX = /^(https?:)?\/\//i;
 
 var CssProcessor = module.exports = function(fileContent, lineFeed, options) {
 	this.fileContent = fileContent;
+	options = options || {};
 	options.addFilenameComment = options.addFilenameComment || false;
 	this.options = options;
 	this.lineFeed = lineFeed;

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.11.2",
-    "grunt-contrib-clean": "~0.7.0",
-    "grunt-contrib-nodeunit": "~0.4.1",
-    "grunt": "~0.4.5",
-    "grunt-conventional-changelog": "~5.0.0"
+    "grunt-contrib-jshint": "~1.0.0",
+    "grunt-contrib-clean": "~1.0.0",
+    "grunt-contrib-nodeunit": "~1.0.0",
+    "grunt": "~1.0.1",
+    "grunt-conventional-changelog": "~6.1.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4.5"
+    "grunt": ">=0.4.5"
   },
   "keywords": [
     "gruntplugin",

--- a/test/cssprocessor_test.js
+++ b/test/cssprocessor_test.js
@@ -10,7 +10,7 @@ exports.fscss = {
   },
   intializeCorrectly: function(test) {
     test.expect(1);
-    var cssp = new CssProcessor("filecontent", "\n", false);
+    var cssp = new CssProcessor("filecontent", "\n");
     test.equal(cssp.fileContent, "filecontent", "should initalize fileContent correctly");
     test.done();
   },


### PR DESCRIPTION
Hi,

hab' mal u.a. wg. der grunt peerDependency alle devDependencies und alle peerDependencies aktualisiert. grunt test läuft ohne Fehler durch.
In der CssProcessor habe ich options noch standardmäßig vorbelegt, weil ich nach dem Auschecken der letzten Version 2 Fehler im Test bekam, weil options in einem Test mit false übergeben wurde und kein leeres Objekt.

Muss ich noch was anderes beachten, tun? Ist mein erster Pull Request ;)
Gruß,
Tibor
