### PR TITLE
SVG data URIs with rgba/gradient references will get replace but shoudn't

### DIFF
--- a/lib/cssprocessor.js
+++ b/lib/cssprocessor.js
@@ -28,7 +28,8 @@ CssProcessor.prototype.processFile = function() {
 		lineFilenameComments = [];
 
 		// replace url() calls in current line
-		lineContent = lineContent.replace(/url\(\s*['"]?([^'"\)#?]+)(?:[#?](?:[^'"\)]*))?['"]?\s*\)/gm, function (match, src) {
+		lineContent = lineContent.replace(/url\(\s*['"]?([^'"#?]+)(?:[#?](?:[^'"\)]*))?['"]?\s*\)/gm, function (match, src) {
+		//lineContent = lineContent.replace(/url\(\s*(('[^'$]+')|("[^"$]+")|([^"'$\)]+))\s*\)/gm, function (match, src) {
 			abs = (this.options.abs != null) ? this.options.abs : null;
 
 			// dont replace empty matches

--- a/test/cssprocessor_test.js
+++ b/test/cssprocessor_test.js
@@ -131,6 +131,27 @@ exports.fscss = {
     test.equal(cssp.processFile(), expected, "should not replace @ chars");
     test.done();
   },
+
+  inlineSVGDataURIWithUrl: function(test) {
+    test.expect(1);
+    var cssp = new CssProcessor("body{background: url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2050%2050%22%3E%3ClinearGradient%20id%3D%22a%22%20gradientUnits%3D%22userSpaceOnUse%22%20x1%3D%225%22%20y1%3D%2225%22%20x2%3D%2245%22%20y2%3D%2225%22%3E%3Cstop%20offset%3D%220%22%20stop-color%3D%22%23ED2024%22%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23FAED23%22%2F%3E%3C%2FlinearGradient%3E%3Cpath%20fill%3D%22url(%23a)%22%20d%3D%22M5%205h40v40H5z%22%2F%3E%3C%2Fsvg%3E');}", "\n", {
+      addFilenameComment: false
+    });
+    var expected = "body{background: url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2050%2050%22%3E%3ClinearGradient%20id%3D%22a%22%20gradientUnits%3D%22userSpaceOnUse%22%20x1%3D%225%22%20y1%3D%2225%22%20x2%3D%2245%22%20y2%3D%2225%22%3E%3Cstop%20offset%3D%220%22%20stop-color%3D%22%23ED2024%22%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22%23FAED23%22%2F%3E%3C%2FlinearGradient%3E%3Cpath%20fill%3D%22url(%23a)%22%20d%3D%22M5%205h40v40H5z%22%2F%3E%3C%2Fsvg%3E');}";
+    test.equal(cssp.processFile(), expected, "should not replace data uri");
+    test.done();
+  },
+
+  inlineSVGDataURIWithUrlAndRGBAColor: function(test) {
+    test.expect(1);
+    var cssp = new CssProcessor("body{background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2050%2050%22%3E%3ClinearGradient%20id%3D%22a%22%20gradientUnits%3D%22userSpaceOnUse%22%20x1%3D%225%22%20y1%3D%2225%22%20x2%3D%2245%22%20y2%3D%2225%22%3E%3Cstop%20offset%3D%220%22%20stop-color%3D%22%23ED2024%22%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22rgba(0%2C%20255%2C%20255%2C%20.5)%22%2F%3E%3C%2FlinearGradient%3E%3Cpath%20fill%3D%22url(%23a)%22%20d%3D%22M5%205h40v40H5z%22%2F%3E%3C%2Fsvg%3E');}", "\n", {
+      addFilenameComment: false
+    });
+    var expected = "body{background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2050%2050%22%3E%3ClinearGradient%20id%3D%22a%22%20gradientUnits%3D%22userSpaceOnUse%22%20x1%3D%225%22%20y1%3D%2225%22%20x2%3D%2245%22%20y2%3D%2225%22%3E%3Cstop%20offset%3D%220%22%20stop-color%3D%22%23ED2024%22%2F%3E%3Cstop%20offset%3D%221%22%20stop-color%3D%22rgba(0%2C%20255%2C%20255%2C%20.5)%22%2F%3E%3C%2FlinearGradient%3E%3Cpath%20fill%3D%22url(%23a)%22%20d%3D%22M5%205h40v40H5z%22%2F%3E%3C%2Fsvg%3E');}";
+    test.equal(cssp.processFile(), expected, "should not replace data uri");
+    test.done();
+  },
+
   base64png: function(test) {
     test.expect(1);
     var cssp = new CssProcessor("body{background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAFWHRTb2Z0d2FyZQBBZG);}", "\n", {


### PR DESCRIPTION
When you have data URIs with SVGs and the SVG references a `linearGradient` inside itself this can be done via an `url(…)` inside the `url(…)`. This doesn't seems to get changed by the task.

Anyhow if this gradient has color information in `rgba()` notation which will introduce another pair of parenthesis  to the mix the `url()` which references the gradient will get replaced by $CMS$ tokens.

I added tests to catch this. I also changed the RegEx to satisfy the tests, by removing the exclusion of parenthesis in the first group. Not sure how many things the RegEx is supposed to catch though. 

I first tried a simpler RegEx for `url()`s with `"`, `'` or none. But this didn't work out ( `/url\(\s*(('[^']+')|("[^"]+")|([^"'\)]+))\s*\)/`).
