### PR TITLE
ADDED fix for embedded woff font files and tests

### DIFF
--- a/lib/cssprocessor.js
+++ b/lib/cssprocessor.js
@@ -128,5 +128,5 @@ CssProcessor.prototype.isBase64Data = function(filename) {
 	if (typeof filename !== 'string') {
 		return false;
 	}
-	return /^data:[a-zA-Z0-9 \/+]+([; ]+)?(charset\=(\")?.+(\")?)?(\w+?base64(\w+)?,(\w)?)?\w+?,.*/ig.test(filename);
+	return /^data:[a-zA-Z0-9 \/+\-]+([; ]+)?(charset\=(\")?.+(\")?)?(\w+?base64(\w+)?,(\w)?)?\w+?,.*/ig.test(filename);
 };

--- a/test/cssprocessor_test.js
+++ b/test/cssprocessor_test.js
@@ -10,7 +10,9 @@ exports.fscss = {
   },
   intializeCorrectly: function(test) {
     test.expect(1);
-    var cssp = new CssProcessor("filecontent", "\n", false);
+    var cssp = new CssProcessor("filecontent", "\n", {
+      addFilenameComment: false
+    });
     test.equal(cssp.fileContent, "filecontent", "should initalize fileContent correctly");
     test.done();
   },
@@ -177,6 +179,15 @@ exports.fscss = {
       addFilenameComment: false
     });
     test.equal(cssp.processFile(), style, 'should not rewrite data urls with charset');
+    test.done();
+  },
+  xFontWoff: function(test) {
+    test.expect(1);
+    var cssp = new CssProcessor("@font-face{url(data:application/x-font-woff;base64,iVBORw0KGgoAAAANSUhEUgAAFWHRTb2Z0d2FyZQBBZG+/tj24);}", "\n", {
+      addFilenameComment: false
+    });
+    var expected = "@font-face{url(data:application/x-font-woff;base64,iVBORw0KGgoAAAANSUhEUgAAFWHRTb2Z0d2FyZQBBZG+/tj24);}";
+    test.equal(cssp.processFile(), expected, "should not replace woff data");
     test.done();
   },
   basicFileMapping: function(test) {


### PR DESCRIPTION
Stumbled upon a problem with embedded font files with WOFF mime type containing dashes 